### PR TITLE
Fix for UnboundLocalError: local variable 'driver' referenced before assignment tvDataFeed

### DIFF
--- a/tvDatafeed/main.py
+++ b/tvDatafeed/main.py
@@ -253,7 +253,7 @@ class TvDatafeed:
             )
         else:
             options.add_argument(f"user-data-dir={self.profile_dir}")
-
+        driver = None
         try:
             if not self.__automatic_login:
                 print(
@@ -277,7 +277,8 @@ class TvDatafeed:
             return driver
 
         except Exception as e:
-            driver.quit()
+            if driver is not None:
+                driver.quit()
             logger.error(e)
 
     @staticmethod


### PR DESCRIPTION
The error happens due to firing the `driver.quit()` at line 280 in the case when 
```
driver = webdriver.Chrome(
    self.chromedriver_path, desired_capabilities=caps, options=options
)
```
at line 268 has not been reached.

I've just added the `driver` instantiation before try catch and in the catch a check before actually firing the quit function.